### PR TITLE
chore: added basic postgres support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,50 @@ Note: This video is slightly outdated. The bot now uses `/` to start commands an
 
 Since we need to connect to both ESI and discord, there is sadly still some things to do.
 TLDR: Create an env file and fill it in with the CCP and Discord info, then run with docker compose.
+
+### Database Support
+The bot now supports both SQLite (default) and PostgreSQL databases. PostgreSQL is automatically included in the Docker Compose setup.
+
 1. Clone this repository
     ```shell
     git clone https://github.com/14rynx/timer-bot.git
     ```
    
-2. Copy the .env file from the example
+2. Create the .env file with the required configuration:
     ```shell
-    cp .env.example .env
+    touch .env
+    ```
+    
+    Add the following variables to your .env file:
+    ```bash
+    # Discord Bot Configuration
+    DISCORD_TOKEN=your_discord_bot_token_here
+    
+    # EVE Online ESI API Configuration
+    CCP_CLIENT_ID=your_ccp_client_id_here
+    CCP_SECRET_KEY=your_ccp_secret_key_here
+    CCP_REDIRECT_URI=https://yourdomain.com/callback
+    
+    # Database Configuration
+    # Set to 'postgresql' to use PostgreSQL, or 'sqlite' (default) for SQLite
+    DB_TYPE=postgresql
+    DB_PASSWORD=your_secure_password_here
+    
+    # Optional PostgreSQL settings (defaults shown)
+    DB_HOST=postgres
+    DB_NAME=timer_bot
+    DB_USER=postgres
+    DB_PORT=5432
+    
+    # For SQLite (when DB_TYPE=sqlite)
+    DB_PATH=data/bot.sqlite
+    
+    # Logging
+    LOG_LEVEL=INFO
+    
+    # For Traefik setup
+    DOMAIN=yourdomain.com
+    LE_EMAIL=your_email@example.com
     ```
 
 3. Head over to the [Discord Developers Website](https://discord.com/developers/) and create yourself an application.
@@ -49,23 +85,25 @@ TLDR: Create an env file and fill it in with the CCP and Discord info, then run 
     - Under "Permissions" add `esi-universe.read_structures.v1, esi-corporations.read_structures.v1, esi-characters.read_notifications.v1`
     - Under "Callback URL" set `https://yourdomain.com/callback/` (obviously replace your domain)
 
-    Now view the application and copy the values `CCP_REDIRECT_URI`, `CCP_CLIENT_ID` and `CCP_SECRET_KEY` to your .env file.
+    Now view the application and copy the values to your .env file as `CCP_REDIRECT_URI`, `CCP_CLIENT_ID` and `CCP_SECRET_KEY`.
 
 5. Start the container.
+    The Docker Compose setup now includes PostgreSQL by default. Both configurations have been updated to support the new database options.
+    
     + If you run traefik as a reverse-proxy externally:
       ```shell
       docker-compose up -d --build
       ```
     
     + If you want to run this without any external reverse proxy:
-      - Add the `LE_EMAIL=your_email@mailserver.com` to the .env file so that letsencrypt certbot can send you info about your https certificates
+      - Ensure `LE_EMAIL=your_email@mailserver.com` is set in the .env file so that letsencrypt certbot can send you info about your https certificates
       - Run the docker compose with both timer-bot and traefik with the following command
       ```shell
       docker-compose up -d --build -f docker-compose+traefik.yml
       ```
 
-6. You can now invite the bot to your server and continue like the public instance.
-   You should be able to get an invite link from the discord admin panel, or you can fill in the blank in this one
-   ```
-   https://discord.com/oauth2/authorize?client_id=<YOUR_CLIENT_ID_GOES_HERE>&permissions=3072&scope=bot
-   ```
+    **Note**: When using PostgreSQL (`DB_TYPE=postgresql`), the bot will automatically connect to the PostgreSQL container. When using SQLite (`DB_TYPE=sqlite`), the bot will use the local SQLite file as before.
+
+### Migrating from SQLite to PostgreSQL
+
+Migration is not supported.

--- a/docker-compose+traefik.yml
+++ b/docker-compose+traefik.yml
@@ -1,12 +1,34 @@
 services:
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    container_name: timer-bot-postgres
+    environment:
+      POSTGRES_DB: timer_bot
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - timer-network
+
   timer:
     build: '.'
     restart: unless-stopped
     container_name: timer-bot
     env_file:
       .env
+    environment:
+      - DB_TYPE=${DB_TYPE:-sqlite}
+      - DB_HOST=${DB_HOST:-postgres}
+      - DB_NAME=${DB_NAME:-timer_bot}
+      - DB_USER=${DB_USER:-postgres}
+      - DB_PASSWORD=${DB_PASSWORD:-postgres}
+      - DB_PORT=${DB_PORT:-5432}
     volumes:
       - ./data:/data/
+    depends_on:
+      - postgres
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=web"
@@ -17,6 +39,7 @@ services:
       - "traefik.http.services.timer-secure.loadbalancer.server.port=80"
     networks:
       - web
+      - timer-network
 
   traefik:
     image: "traefik:v2.3"
@@ -48,6 +71,9 @@ services:
 
 volumes:
   data:
+  postgres_data:
 networks:
   web:
     external: true
+  timer-network:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,34 @@
 services:
+  postgres:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    container_name: timer-bot-postgres
+    environment:
+      POSTGRES_DB: timer_bot
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - timer-network
+
   timer:
     build: '.'
     restart: unless-stopped
     container_name: timer-bot
     env_file:
       .env
+    environment:
+      - DB_TYPE=${DB_TYPE:-sqlite}
+      - DB_HOST=${DB_HOST:-postgres}
+      - DB_NAME=${DB_NAME:-timer_bot}
+      - DB_USER=${DB_USER:-postgres}
+      - DB_PASSWORD=${DB_PASSWORD:-postgres}
+      - DB_PORT=${DB_PORT:-5432}
     volumes:
       - ./data:/data/
+    depends_on:
+      - postgres
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=web"
@@ -17,8 +39,12 @@ services:
       - "traefik.http.services.timer-secure.loadbalancer.server.port=80"
     networks:
       - web
+      - timer-network
 volumes:
   data:
+  postgres_data:
 networks:
   web:
     external: true
+  timer-network:
+    driver: bridge

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 discord
 peewee
 preston
+psycopg2-binary

--- a/src/models.py
+++ b/src/models.py
@@ -1,7 +1,24 @@
+import os
 from peewee import *
 
-# Initialize the database
-db = SqliteDatabase('data/bot.sqlite')
+# Initialize the database based on environment variables
+def get_database():
+    """Get database instance based on environment configuration."""
+    db_type = os.getenv('DB_TYPE', 'sqlite').lower()
+    
+    if db_type == 'postgresql':
+        return PostgresqlDatabase(
+            os.getenv('DB_NAME', 'timer_bot'),
+            user=os.getenv('DB_USER', 'postgres'),
+            password=os.getenv('DB_PASSWORD', ''),
+            host=os.getenv('DB_HOST', 'localhost'),
+            port=int(os.getenv('DB_PORT', '5432'))
+        )
+    else:
+        # Default to SQLite
+        return SqliteDatabase(os.getenv('DB_PATH', 'data/bot.sqlite'))
+
+db = get_database()
 
 
 class BaseModel(Model):


### PR DESCRIPTION
# Rational
SQLite + local storage doesn’t work well on Kubernetes: Pods are ephemeral, PVCs tie you to one node, and SQLite can’t handle multi-replica writes. Using RWX/NFS with SQLite is unsafe due to locking issues and poor performance.
Backups, HA, and scaling are all painful compared to a real DB. We should migrate to Postgres/MySQL (managed or via operator) for reliability, backups, and multi-replica support.
# Changes
Updated the implementation to just have Postgres support.